### PR TITLE
Added missing dependency to Database::Migrator::Core (File::Slurp).

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 {{$NEXT}}
 
+- Added missing dependency (File::Slurp).
+
 0.07     2013-06-16
 
 - Require implementations to provide the driver name rather than trying to

--- a/lib/Database/Migrator/Core.pm
+++ b/lib/Database/Migrator/Core.pm
@@ -7,6 +7,7 @@ use namespace::autoclean;
 use Database::Migrator::Types qw( ArrayRef Bool Dir File Maybe Str );
 use DBI;
 use Eval::Closure qw( eval_closure );
+use File::Slurp qw( read_file );
 use Log::Dispatch;
 use Moose::Util::TypeConstraints qw( duck_type );
 


### PR DESCRIPTION
No tests added as it looks like it would be hard to test this without db connections etc. Would be good to add something like that, though.
