### PR TITLE
Separate DBI connection config from builder

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 {{$NEXT}}
 
+- Separated dbh connection configuration from builder into two private
+  attributes, facilitating less invasive subclassing.
+
 0.12     2017-03-10
 
 - Replaced unnecessary use of File::Slurp with Path::Class::File's slurp

--- a/lib/Database/Migrator/Core.pm
+++ b/lib/Database/Migrator/Core.pm
@@ -84,20 +84,20 @@ has __pending_migrations => (
 
 has _dsn => (
     traits   => ['NoGetopt'],
-    is => 'ro',
-    isa => Str,
+    is       => 'ro',
+    isa      => Str,
     init_arg => undef,
-    lazy => 1,
-    builder => '_build_dsn',
+    lazy     => 1,
+    builder  => '_build_dsn',
 );
 
 has _dbh_attr => (
     traits   => ['NoGetopt'],
-    is => 'ro',
-    isa => HashRef,
+    is       => 'ro',
+    isa      => HashRef,
     init_arg => undef,
-    lazy => 1,
-    builder => '_build_dbh_attr',
+    lazy     => 1,
+    builder  => '_build_dbh_attr',
 );
 
 has dbh => (


### PR DESCRIPTION
Database::Migrator::Pg depends on installed Postgres utilities createdb and dropdb, both of which work with local and remote database servers, but as soon as its time to apply a migration, it attempts to create a DBI connection, which fails for remote database servers.

The primary concern I have at the moment is that Database::Migrator::Pg doesn't work for remote database servers because Database::Migrator::Core hardcodes DBI's dsn without host or port parameters. I could overwrite ::Core's _build_dbh method in my Database::Migrator::Pg subclass, but that seems a little too invasive, and we can do it better without a breaking change to the API. 

This PR separates dbh connection configuration from its builder into two private attributes, which will facilitate less invasive subclassing. I plan to follow up with a PR to Database::Migrator::Pg which will override the _build_dsn method to include host and port when they are present in the object.

Finally, there's the matter of tests. In t/, there's a single test. I also see the Test::Migrator::Database class, but I'm not sure if it's being used for tests, and if so, what mechanism is using it for tests currently. Please steer me here.